### PR TITLE
Fix Caddyfile parsing when command is not inline

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -63,12 +63,11 @@ func parseHandlerCaddyfile(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue,
 //   }
 //
 func (m *Cmd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	// command, if present.
-	if d.Next() {
-		if !d.Args(&m.Command) {
-			return d.ArgErr()
-		}
+	// consume "exec", then grab the command, if present.
+	if d.NextArg() && d.NextArg() {
+		m.Command = d.Val()
 	}
+
 	// everything else are args, if present.
 	m.Args = d.RemainingArgs()
 


### PR DESCRIPTION
This issue was found by @tobya

This Caddyfile would fail to adapt because `Next()` will read the `exec` token then return true, but then `Args()` will find no args and fail.

Instead, I use `NextArg()` to skip `exec`, then `NextArg()` to move the cursor to the command if it exists, and then grab the token value if a command exists.

This Caddyfile shows the problem:
```
:80 {
    route {
        exec {
            command c:\path\to\php.exe
            args -b 2222
            startup
        }
    }
}
```