### PR TITLE
Allow requests to pass through exec middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ exec [<matcher>] [<command> [<args...>]] {
     log         <log output module>
     err_log     <log output module>
     foreground
+    pass_thru
     startup
     shutdown
 }
@@ -41,6 +42,7 @@ exec [<matcher>] [<command> [<args...>]] {
 - **log** - [Caddy log output module](https://caddyserver.com/docs/caddyfile/directives/log#output-modules) for standard output log. Defaults to `stderr`.
 - **err_log** - [Caddy log output module](https://caddyserver.com/docs/caddyfile/directives/log#output-modules) for standard error log. Defaults to the value of `log` (standard output log).
 - **foreground** - if present, runs the command in the foreground. For commands at http endpoints, the command will exit before the http request is responded to.
+- **pass_thru** - if present, enables pass-thru mode, which continues to the next HTTP handler in the route instead of responding directly
 - **startup** - if present, run the command at startup. Ignored in routes.
 - **shutdown** - if present, run the command at shutdown. Ignored in routes.
 
@@ -95,6 +97,8 @@ As a top level app for `startup` and `shutdown` commands.
           "directory": "",
           // [optional] if the command should run on the foreground. Default is false.
           "foreground": false,
+          // [optional] if the middleware should respond directly or pass the request on to the next handler in the route. Default is false.
+          "pass_thru": false,
           // [optional] timeout to terminate the command's process. Default is 10s.
           "timeout": "10s",
           // [optional] log output module config for standard output. Default is `stderr` module.
@@ -137,6 +141,8 @@ As an handler within a route.
           "directory": "/home/user/site/public",
           // [optional] if the command should run on the foreground. Default is false.
           "foreground": true,
+          // [optional] if the middleware should respond directly or pass the request on to the next handler in the route. Default is false.
+          "pass_thru": true,
           // [optional] timeout to terminate the command's process. Default is 10s.
           "timeout": "5s",
           // [optional] log output module config for standard output. Default is `stderr` module.

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -23,7 +23,7 @@ func newCommandFromDispenser(d *caddyfile.Dispenser) (cmd Cmd, err error) {
 // parseHandlerCaddyfileBlock configures the handler directive from Caddyfile.
 // Syntax:
 //
-//	exec [<matcher>] [<command> [<args...>]] {
+//	  exec [<matcher>] [<command> [<args...>]] {
 //	    command     <text>
 //	    args        <text>...
 //	    directory   <text>
@@ -43,7 +43,7 @@ func parseHandlerCaddyfileBlock(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHan
 // parseGlobalCaddyfileBlock configures the "exec" global option from Caddyfile.
 // Syntax:
 //
-//	exec [<command> [<args...>]] {
+//	  exec [<command> [<args...>]] {
 //	    command     <text>...
 //	    args        <text>...
 //	    directory   <text>
@@ -91,7 +91,7 @@ func parseGlobalCaddyfileBlock(d *caddyfile.Dispenser, prev interface{}) (interf
 // UnmarshalCaddyfile configures the handler directive from Caddyfile.
 // Syntax:
 //
-//	exec [<matcher>] [<command> [<args...>]] {
+//	  exec [<matcher>] [<command> [<args...>]] {
 //	    command     <text>
 //	    args        <text>...
 //	    directory   <text>

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -23,18 +23,18 @@ func newCommandFromDispenser(d *caddyfile.Dispenser) (cmd Cmd, err error) {
 // parseHandlerCaddyfileBlock configures the handler directive from Caddyfile.
 // Syntax:
 //
-//   exec [<matcher>] [<command> [<args...>]] {
-//       command     <text>
-//       args        <text>...
-//       directory   <text>
-//       timeout     <duration>
-//       log         <log output module>
-//       err_log     <log output module>
-//       foreground
-//       startup
-//       shutdown
-//   }
-//
+//	exec [<matcher>] [<command> [<args...>]] {
+//	    command     <text>
+//	    args        <text>...
+//	    directory   <text>
+//	    timeout     <duration>
+//	    log         <log output module>
+//	    err_log     <log output module>
+//	    foreground
+//	    pass_thru
+//	    startup
+//	    shutdown
+//	}
 func parseHandlerCaddyfileBlock(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
 	cmd, err := newCommandFromDispenser(h.Dispenser)
 	return Middleware{Cmd: cmd}, err
@@ -43,18 +43,18 @@ func parseHandlerCaddyfileBlock(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHan
 // parseGlobalCaddyfileBlock configures the "exec" global option from Caddyfile.
 // Syntax:
 //
-//   exec [<command> [<args...>]] {
-//       command     <text>...
-//       args        <text>...
-//       directory   <text>
-//       timeout     <duration>
-//       log         <log output module>
-//       err_log     <log output module>
-//       foreground
-//       startup
-//       shutdown
-//   }
-//
+//	exec [<command> [<args...>]] {
+//	    command     <text>...
+//	    args        <text>...
+//	    directory   <text>
+//	    timeout     <duration>
+//	    log         <log output module>
+//	    err_log     <log output module>
+//	    foreground
+//	    pass_thru
+//	    startup
+//	    shutdown
+//	}
 func parseGlobalCaddyfileBlock(d *caddyfile.Dispenser, prev interface{}) (interface{}, error) {
 	var exec App
 
@@ -91,18 +91,18 @@ func parseGlobalCaddyfileBlock(d *caddyfile.Dispenser, prev interface{}) (interf
 // UnmarshalCaddyfile configures the handler directive from Caddyfile.
 // Syntax:
 //
-//   exec [<matcher>] [<command> [<args...>]] {
-//       command     <text>
-//       args        <text>...
-//       directory   <text>
-//       timeout     <duration>
-//       log         <log output module>
-//       err_log     <log output module>
-//       foreground
-//       startup
-//       shutdown
-//   }
-//
+//	exec [<matcher>] [<command> [<args...>]] {
+//	    command     <text>
+//	    args        <text>...
+//	    directory   <text>
+//	    timeout     <duration>
+//	    log         <log output module>
+//	    err_log     <log output module>
+//	    foreground
+//	    pass_thru
+//	    startup
+//	    shutdown
+//	}
 func (c *Cmd) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	// consume "exec", then grab the command, if present.
 	if d.NextArg() && d.NextArg() {
@@ -138,6 +138,8 @@ func (c *Cmd) unmarshalBlock(d *caddyfile.Dispenser) error {
 			}
 		case "foreground":
 			c.Foreground = true
+		case "pass_thru":
+			c.PassThru = true
 		case "startup":
 			c.At = append(c.At, "startup")
 		case "shutdown":

--- a/command.go
+++ b/command.go
@@ -31,6 +31,10 @@ type Cmd struct {
 	// foreground may prevent Caddy from starting.
 	Foreground bool `json:"foreground,omitempty"`
 
+	// Enables pass-thru mode, which continues to the next HTTP
+	// handler in the route instead of responding directly
+	PassThru bool `json:"pass_thru,omitempty"`
+
 	// Timeout for the command. The command will be killed
 	// after timeout has elapsed if it is still running.
 	// Defaults to 10s.


### PR DESCRIPTION
Rather than always responding to the request with the result of the executed command, it can be desirable to simply run commands as a _side-effect_ of handling a route in a given middleware chain. This enables use cases such as:

- regeneration of static assets just before serving them
- (re)starting proxy servers just prior to sending them a request
- alerting when certain routes are accessed
- etc 

Note that the configuration name "`pass_thru`" was chosen to mirror the analogous configuration found in the `file_server` module: https://caddyserver.com/docs/caddyfile/directives/file_server#pass_thru 

Implements https://github.com/abiosoft/caddy-exec/issues/15