### PR TITLE
fix processing of the args option

### DIFF
--- a/command.go
+++ b/command.go
@@ -17,8 +17,7 @@ type Cmd struct {
 	Command string `json:"command,omitempty"`
 
 	// The command args.
-	Args []string
-	Argv []string `json:"args,omitempty"`
+	Args []string `json:"args,omitempty"`
 
 	// The directory to run the command from.
 	// Defaults to current directory.

--- a/middleware.go
+++ b/middleware.go
@@ -42,13 +42,13 @@ func (m Middleware) Validate() error { return m.Cmd.validate() }
 func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
+	// replace per-request placeholders
 	argv := make([]string, len(m.Args))
 	for index, argument := range m.Args {
 		argv[index] = repl.ReplaceAll(argument, "")
 	}
-	m.Argv = argv
 
-	err := m.run()
+	err := m.run(argv)
 
 	if m.PassThru {
 		if err != nil {
@@ -77,6 +77,5 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 // Cleanup implements caddy.Cleanup
 // TODO: ensure all running processes are terminated.
 func (m *Middleware) Cleanup() error {
-	m.Argv = nil
 	return nil
 }

--- a/run.go
+++ b/run.go
@@ -17,12 +17,12 @@ type runnerFunc func() error
 
 func (r runnerFunc) Run() error { return r() }
 
-func (c *Cmd) run() error {
-	cmdInfo := zap.Any("command", append([]string{c.Command}, c.Argv...))
+func (c *Cmd) run(args []string) error {
+	cmdInfo := zap.Any("command", append([]string{c.Command}, args...))
 	log := c.log.With(cmdInfo)
 	startTime := time.Now()
 
-	cmd := exec.Command(c.Command, c.Argv...)
+	cmd := exec.Command(c.Command, args...)
 
 	done := make(chan struct{}, 1)
 
@@ -36,7 +36,7 @@ func (c *Cmd) run() error {
 			cancel()
 		}()
 
-		cmd = exec.CommandContext(ctx, c.Command, c.Argv...)
+		cmd = exec.CommandContext(ctx, c.Command, args...)
 	}
 
 	// configure command


### PR DESCRIPTION
Merging the latest PR broke passing of arguments to commands. This PR will fix this issue. It also preserves the replacement placeholder values per request. Additionally, placeholders can now also be used in global commands.

The previous approach was prone to cause race conditions on heavily loaded proxies due to using shared memory for the replaced arguments which has also been addressed.